### PR TITLE
feat(semver): add inc function

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const {
   major,
   minor,
   patch,
+  inc,
 } = require('./lib/semantic');
 
 module.exports = {
@@ -59,4 +60,5 @@ module.exports = {
     major,
     minor,
     patch,
+    inc,
 };

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -1,10 +1,11 @@
-const { explain } = require('./version');
+const { explain, parse, stringify } = require('./version');
 
 // those notation are borrowed from semver
 module.exports = {
     major,
     minor,
     patch,
+    inc,
 };
 
 function major(input) {
@@ -37,3 +38,53 @@ function patch(input) {
     return version.release[2];
 };
 
+function inc(input, release) {
+    const version = parse(input);
+
+    if (!version) {
+        return null;
+    }
+
+    switch(release) {
+        case 'major':
+            if (version.release.slice(1).some(value => value !== 0) || (version.pre === null)) {
+                const [majorVersion] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion + 1;
+            }
+            delete version.pre;
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        case 'minor':
+            if (version.release.slice(2).some(value => value !== 0) || (version.pre === null)) {
+                const [majorVersion, minorVersion=0] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion;
+                version.release[1] = minorVersion + 1;
+            }
+            delete version.pre;
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        case 'patch':
+            if (version.release.slice(3).some(value => value !== 0) || (version.pre === null)) {
+                const [majorVersion, minorVersion=0, patchVersion=0] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion;
+                version.release[1] = minorVersion;
+                version.release[2] = patchVersion + 1;
+            }
+            delete version.pre;
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        default:
+            return null;
+    }
+
+    return stringify(version);
+}

--- a/lib/version.js
+++ b/lib/version.js
@@ -38,6 +38,7 @@ module.exports = {
     clean,
     explain,
     parse,
+    stringify,
 }
 
 const validRegex = new XRegExp('^' + VERSION_PATTERN + '$', 'i');

--- a/test/semantic.test.js
+++ b/test/semantic.test.js
@@ -4,6 +4,7 @@ const {
   major,
   minor,
   patch,
+  inc,
 } = require('../');
 
 
@@ -41,4 +42,129 @@ describe('patch(version)', () => {
   it('throws when version invalid', () => {
     expect(() => patch('not_version')).toThrowError(TypeError);
   });
+});
+
+describe('inc(version, release)', () => {
+  const testCases = [
+    // [ existing version, release type (`major`, `minor`, `patch`), identifier (`a`, `b`, `rc`, etc.), expected result ]
+
+    // Semantic Version numbers only.
+    ['0.0.0', 'major', undefined, '1.0.0'],
+    ['1.0.0', 'major', undefined, '2.0.0'],
+    ['1.0.1', 'major', undefined, '2.0.0'],
+    ['1.1.0', 'major', undefined, '2.0.0'],
+    ['0.0.0', 'minor', undefined, '0.1.0'],
+    ['1.0.0', 'minor', undefined, '1.1.0'],
+    ['1.0.1', 'minor', undefined, '1.1.0'],
+    ['1.1.0', 'minor', undefined, '1.2.0'],
+    ['0.0.0', 'patch', undefined, '0.0.1'],
+    ['1.0.0', 'patch', undefined, '1.0.1'],
+    ['1.0.1', 'patch', undefined, '1.0.2'],
+    ['1.1.0', 'patch', undefined, '1.1.1'],
+
+    // Extra release segments, as allowed by PEP440.
+    ['1.1.1.1', 'major', undefined, '2.0.0.0'],
+    ['1.1.1.1', 'minor', undefined, '1.2.0.0'],
+    ['1.1.1.1', 'patch', undefined, '1.1.2.0'],
+
+    // Without padding, as allowed by PEP440.
+    ['1', 'major', undefined, '2'],
+    ['1.0', 'major', undefined, '2.0'],
+    ['1', 'minor', undefined, '1.1'],
+    ['1.0', 'minor', undefined, '1.1'],
+    ['1', 'patch', undefined, '1.0.1'],
+    ['1.0', 'patch', undefined, '1.0.1'],
+
+    // Pre-release versions.
+    ['1.0.0a1', 'major', undefined, '1.0.0'],
+    ['1.1.1a1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc1', 'major', undefined, '2.0.0'],
+    ['1.0.0a1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc1', 'minor', undefined, '1.2.0'],
+    ['1.0.0a1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc1', 'patch', undefined, '1.1.1'],
+
+    // Post-release versions.
+    ['1.0.0.post1', 'major', undefined, '2.0.0'],
+    ['1.1.1.post1', 'major', undefined, '2.0.0'],
+    ['1.0.0.post1', 'minor', undefined, '1.1.0'],
+    ['1.1.1.post1', 'minor', undefined, '1.2.0'],
+    ['1.0.0.post1', 'patch', undefined, '1.0.1'],
+    ['1.1.1.post1', 'patch', undefined, '1.1.2'],
+
+    // Post-releases of pre-release versions.
+    ['1.0.0a1.post1', 'major', undefined, '1.0.0'],
+    ['1.1.1a1.post1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc1.post1', 'major', undefined, '2.0.0'],
+    ['1.0.0a1.post1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a1.post1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc1.post1', 'minor', undefined, '1.2.0'],
+    ['1.0.0a1.post1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a1.post1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc1.post1', 'patch', undefined, '1.1.1'],
+
+    // Development-release versions.
+    ['1.0.0.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1.dev1', 'major', undefined, '2.0.0'],
+    ['1.0.0.dev1', 'minor', undefined, '1.1.0'],
+    ['1.1.1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.0.0.dev1', 'patch', undefined, '1.0.1'],
+    ['1.1.1.dev1', 'patch', undefined, '1.1.2'],
+
+    // Development-releases of pre-release versions.
+    ['1.0.0a1.dev1', 'major', undefined, '1.0.0'],
+    ['1.1.1a1.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc1.dev1', 'major', undefined, '2.0.0'],
+    ['1.0.0a1.dev1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.0.0a1.dev1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a1.dev1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc1.dev1', 'patch', undefined, '1.1.1'],
+
+    // Development-releases of post-release versions.
+    ['1.0.0.post1.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1.post1.dev1', 'major', undefined, '2.0.0'],
+    ['1.0.0.post1.dev1', 'minor', undefined, '1.1.0'],
+    ['1.1.1.post1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.0.0.post1.dev1', 'patch', undefined, '1.0.1'],
+    ['1.1.1.post1.dev1', 'patch', undefined, '1.1.2'],
+
+    // Development-releases of pre-and-post-release versions.
+    ['1.0.0a1.post1.dev1', 'major', undefined, '1.0.0'],
+    ['1.1.1a1.post1.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc1.post1.dev1', 'major', undefined, '2.0.0'],
+    ['1.0.0a1.post1.dev1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a1.post1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc1.post1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.0.0a1.post1.dev1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a1.post1.dev1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc1.post1.dev1', 'patch', undefined, '1.1.1'],
+  ];
+
+  testCases.forEach(testCase =>
+    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${testCase[3]}`, () =>
+    expect(inc(testCase[0], testCase[1], testCase[2])).toBe(testCase[3])));
+
+  testCases.forEach(testCase => {
+    const epochTestCase = testCase;
+    epochTestCase[0] = `1!${epochTestCase[0]}`;
+    epochTestCase[3] = `1!${epochTestCase[3]}`;
+    it(`handles incrementing ${epochTestCase[0]} using ${epochTestCase[1]} to ${epochTestCase[3]}`, () =>
+    expect(inc(epochTestCase[0], epochTestCase[1], epochTestCase[2])).toBe(epochTestCase[3]));
+  });
+
+  const invalidTestCases = [
+    // [ existing version, release type, identifier (`a`, `b`, `rc`, etc.), expected result ]
+
+    // Invalid inputs.
+    ['not_valid', 'major', undefined, null],
+    ['1.0.0', 'invalid_release', undefined, null],
+  ];
+
+  invalidTestCases.forEach(testCase =>
+    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${testCase[3]}`, () =>
+    expect(inc(testCase[0], testCase[1], testCase[2])).toBe(testCase[3])));
 });


### PR DESCRIPTION
Add version incrementing function that mimics the behavior of the
npm package `semver`, with the exception that semantics of Python
PEP440 versioning are supported, such as Epochs.

Closes #11