### PR TITLE
feat(semver): add prereleases to inc function

### DIFF
--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -38,14 +38,80 @@ function patch(input) {
     return version.release[2];
 };
 
-function inc(input, release) {
+function inc(input, release, preReleaseIdentifier) {
+    let identifier = preReleaseIdentifier || `a`;
     const version = parse(input);
 
     if (!version) {
         return null;
     }
 
+    if (![`a`, `b`, `rc`].includes(identifier)) {
+        return null;
+    }
+
     switch(release) {
+        case 'premajor':
+            {
+                const [majorVersion] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion + 1;
+            }
+            version.pre = [identifier, 0];
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        case 'preminor':
+            {
+                const [majorVersion, minorVersion=0] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion;
+                version.release[1] = minorVersion + 1;
+            }
+            version.pre = [identifier, 0];
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        case 'prepatch':
+            {
+                const [majorVersion, minorVersion=0, patchVersion=0] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion;
+                version.release[1] = minorVersion;
+                version.release[2] = patchVersion + 1;
+            }
+            version.pre = [identifier, 0];
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
+        case 'prerelease':
+            if (version.pre === null) {
+                const [majorVersion, minorVersion=0, patchVersion=0] = version.release;
+                version.release.fill(0);
+                version.release[0] = majorVersion;
+                version.release[1] = minorVersion;
+                version.release[2] = patchVersion + 1;
+                version.pre = [identifier, 0];
+            } else {
+                if (preReleaseIdentifier === undefined && version.pre !== null) {
+                     [identifier] = version.pre;
+                }
+
+                const [letter, number] = version.pre;
+                if (letter === identifier) {
+                    version.pre = [letter, number + 1];
+                } else {
+                    version.pre = [identifier, 0];
+                }
+            }
+
+            delete version.post;
+            delete version.dev;
+            delete version.local;
+            break;
         case 'major':
             if (version.release.slice(1).some(value => value !== 0) || (version.pre === null)) {
                 const [majorVersion] = version.release;

--- a/test/semantic.test.js
+++ b/test/semantic.test.js
@@ -46,102 +46,270 @@ describe('patch(version)', () => {
 
 describe('inc(version, release)', () => {
   const testCases = [
-    // [ existing version, release type (`major`, `minor`, `patch`), identifier (`a`, `b`, `rc`, etc.), expected result ]
+    // [ existing version, release type (`major`, `minor`, `patch`), identifier (`a`, `b`, or `rc`.), expected result ]
 
     // Semantic Version numbers only.
     ['0.0.0', 'major', undefined, '1.0.0'],
     ['1.0.0', 'major', undefined, '2.0.0'],
     ['1.0.1', 'major', undefined, '2.0.0'],
     ['1.1.0', 'major', undefined, '2.0.0'],
+
     ['0.0.0', 'minor', undefined, '0.1.0'],
     ['1.0.0', 'minor', undefined, '1.1.0'],
     ['1.0.1', 'minor', undefined, '1.1.0'],
     ['1.1.0', 'minor', undefined, '1.2.0'],
+
     ['0.0.0', 'patch', undefined, '0.0.1'],
     ['1.0.0', 'patch', undefined, '1.0.1'],
     ['1.0.1', 'patch', undefined, '1.0.2'],
     ['1.1.0', 'patch', undefined, '1.1.1'],
 
+    ['0.0.0', 'premajor', undefined, '1.0.0a0'],
+    ['1.0.0', 'premajor', undefined, '2.0.0a0'],
+    ['1.0.1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.0', 'premajor', undefined, '2.0.0a0'],
+
+    ['0.0.0', 'preminor', undefined, '0.1.0a0'],
+    ['1.0.0', 'preminor', undefined, '1.1.0a0'],
+    ['1.0.1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.0', 'preminor', undefined, '1.2.0a0'],
+
+    ['0.0.0', 'prepatch', undefined, '0.0.1a0'],
+    ['1.0.0', 'prepatch', undefined, '1.0.1a0'],
+    ['1.0.1', 'prepatch', undefined, '1.0.2a0'],
+    ['1.1.0', 'prepatch', undefined, '1.1.1a0'],
+
+    ['0.0.0', 'prerelease', undefined, '0.0.1a0'],
+    ['1.0.0', 'prerelease', undefined, '1.0.1a0'],
+    ['1.0.1', 'prerelease', undefined, '1.0.2a0'],
+    ['1.1.0', 'prerelease', undefined, '1.1.1a0'],
+
+    ['0.0.0', 'major', `b`, '1.0.0'],
+    ['0.0.0', 'minor', `b`, '0.1.0'],
+    ['0.0.0', 'patch', `b`, '0.0.1'],
+    ['0.0.0', 'premajor', `b`, '1.0.0b0'],
+    ['0.0.0', 'preminor', `b`, '0.1.0b0'],
+    ['0.0.0', 'prepatch', `b`, '0.0.1b0'],
+    ['0.0.0', 'prerelease', `b`, '0.0.1b0'],
+
     // Extra release segments, as allowed by PEP440.
     ['1.1.1.1', 'major', undefined, '2.0.0.0'],
     ['1.1.1.1', 'minor', undefined, '1.2.0.0'],
     ['1.1.1.1', 'patch', undefined, '1.1.2.0'],
+    ['1.1.1.1', 'premajor', undefined, '2.0.0.0a0'],
+    ['1.1.1.1', 'preminor', undefined, '1.2.0.0a0'],
+    ['1.1.1.1', 'prepatch', undefined, '1.1.2.0a0'],
+    ['1.1.1.1', 'prerelease', undefined, '1.1.2.0a0'],
 
     // Without padding, as allowed by PEP440.
     ['1', 'major', undefined, '2'],
     ['1.0', 'major', undefined, '2.0'],
+
     ['1', 'minor', undefined, '1.1'],
     ['1.0', 'minor', undefined, '1.1'],
+
     ['1', 'patch', undefined, '1.0.1'],
     ['1.0', 'patch', undefined, '1.0.1'],
 
+    ['1', 'premajor', undefined, '2a0'],
+    ['1.0', 'premajor', undefined, '2.0a0'],
+
+    ['1', 'preminor', undefined, '1.1a0'],
+    ['1.0', 'preminor', undefined, '1.1a0'],
+
+    ['1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.0', 'prepatch', undefined, '1.0.1a0'],
+
+    ['1', 'prerelease', undefined, '1.0.1a0'],
+    ['1.0', 'prerelease', undefined, '1.0.1a0'],
+
     // Pre-release versions.
-    ['1.0.0a1', 'major', undefined, '1.0.0'],
-    ['1.1.1a1', 'major', undefined, '2.0.0'],
-    ['1.1.1rc1', 'major', undefined, '2.0.0'],
-    ['1.0.0a1', 'minor', undefined, '1.0.0'],
-    ['1.1.1a1', 'minor', undefined, '1.2.0'],
-    ['1.1.1rc1', 'minor', undefined, '1.2.0'],
-    ['1.0.0a1', 'patch', undefined, '1.0.0'],
-    ['1.1.1a1', 'patch', undefined, '1.1.1'],
-    ['1.1.1rc1', 'patch', undefined, '1.1.1'],
+    ['1.0.0a0', 'major', undefined, '1.0.0'],
+    ['1.1.1a0', 'major', undefined, '2.0.0'],
+    ['1.1.1rc0', 'major', undefined, '2.0.0'],
+
+    ['1.0.0a0', 'minor', undefined, '1.0.0'],
+    ['1.1.1a0', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc0', 'minor', undefined, '1.2.0'],
+
+    ['1.0.0a0', 'patch', undefined, '1.0.0'],
+    ['1.1.1a0', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc0', 'patch', undefined, '1.1.1'],
+
+    ['1.0.0a0', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1a0', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1rc0', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0a0', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1a0', 'preminor', undefined, '1.2.0a0'],
+    ['1.1.1rc0', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0a0', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1a0', 'prepatch', undefined, '1.1.2a0'],
+    ['1.1.1rc0', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0a0', 'prerelease', undefined, '1.0.0a1'],
+    ['1.0.0a1', 'prerelease', undefined, '1.0.0a2'],
+    ['1.0.0b0', 'prerelease', undefined, '1.0.0b1'],
+    ['1.0.0rc0', 'prerelease', undefined, '1.0.0rc1'],
+
+    ['1.0.0a0', 'premajor', `b`, '2.0.0b0'],
+    ['1.0.0a0', 'preminor', `b`, '1.1.0b0'],
+    ['1.0.0a0', 'prepatch', `b`, '1.0.1b0'],
+    ['1.0.0a0', 'prerelease', `b`, '1.0.0b0'],
+
+    ['1.0.0b0', 'prerelease', `b`, '1.0.0b1'],
 
     // Post-release versions.
     ['1.0.0.post1', 'major', undefined, '2.0.0'],
     ['1.1.1.post1', 'major', undefined, '2.0.0'],
+
     ['1.0.0.post1', 'minor', undefined, '1.1.0'],
     ['1.1.1.post1', 'minor', undefined, '1.2.0'],
+
     ['1.0.0.post1', 'patch', undefined, '1.0.1'],
     ['1.1.1.post1', 'patch', undefined, '1.1.2'],
 
+    ['1.0.0.post1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1.post1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0.post1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1.post1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0.post1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1.post1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0.post1', 'prerelease', undefined, '1.0.1a0'],
+    ['1.1.1.post1', 'prerelease', undefined, '1.1.2a0'],
+
     // Post-releases of pre-release versions.
-    ['1.0.0a1.post1', 'major', undefined, '1.0.0'],
-    ['1.1.1a1.post1', 'major', undefined, '2.0.0'],
-    ['1.1.1rc1.post1', 'major', undefined, '2.0.0'],
-    ['1.0.0a1.post1', 'minor', undefined, '1.0.0'],
-    ['1.1.1a1.post1', 'minor', undefined, '1.2.0'],
-    ['1.1.1rc1.post1', 'minor', undefined, '1.2.0'],
-    ['1.0.0a1.post1', 'patch', undefined, '1.0.0'],
-    ['1.1.1a1.post1', 'patch', undefined, '1.1.1'],
-    ['1.1.1rc1.post1', 'patch', undefined, '1.1.1'],
+    ['1.0.0a0.post1', 'major', undefined, '1.0.0'],
+    ['1.1.1a0.post1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc0.post1', 'major', undefined, '2.0.0'],
+
+    ['1.0.0a0.post1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a0.post1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc0.post1', 'minor', undefined, '1.2.0'],
+
+    ['1.0.0a0.post1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a0.post1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc0.post1', 'patch', undefined, '1.1.1'],
+
+    ['1.0.0a0.post1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1a0.post1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1rc0.post1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0a0.post1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1a0.post1', 'preminor', undefined, '1.2.0a0'],
+    ['1.1.1rc0.post1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0a0.post1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1a0.post1', 'prepatch', undefined, '1.1.2a0'],
+    ['1.1.1rc0.post1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0a0.post1', 'prerelease', undefined, '1.0.0a1'],
+    ['1.0.0b0.post1', 'prerelease', undefined, '1.0.0b1'],
+    ['1.0.0rc0.post1', 'prerelease', undefined, '1.0.0rc1'],
 
     // Development-release versions.
     ['1.0.0.dev1', 'major', undefined, '2.0.0'],
     ['1.1.1.dev1', 'major', undefined, '2.0.0'],
+
     ['1.0.0.dev1', 'minor', undefined, '1.1.0'],
     ['1.1.1.dev1', 'minor', undefined, '1.2.0'],
+
     ['1.0.0.dev1', 'patch', undefined, '1.0.1'],
     ['1.1.1.dev1', 'patch', undefined, '1.1.2'],
 
+    ['1.0.0.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1.dev1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0.dev1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1.dev1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0.dev1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1.dev1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0.dev1', 'prerelease', undefined, '1.0.1a0'],
+    ['1.1.1.dev1', 'prerelease', undefined, '1.1.2a0'],
+
     // Development-releases of pre-release versions.
-    ['1.0.0a1.dev1', 'major', undefined, '1.0.0'],
-    ['1.1.1a1.dev1', 'major', undefined, '2.0.0'],
-    ['1.1.1rc1.dev1', 'major', undefined, '2.0.0'],
-    ['1.0.0a1.dev1', 'minor', undefined, '1.0.0'],
-    ['1.1.1a1.dev1', 'minor', undefined, '1.2.0'],
-    ['1.1.1rc1.dev1', 'minor', undefined, '1.2.0'],
-    ['1.0.0a1.dev1', 'patch', undefined, '1.0.0'],
-    ['1.1.1a1.dev1', 'patch', undefined, '1.1.1'],
-    ['1.1.1rc1.dev1', 'patch', undefined, '1.1.1'],
+    ['1.0.0a0.dev1', 'major', undefined, '1.0.0'],
+    ['1.1.1a0.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc0.dev1', 'major', undefined, '2.0.0'],
+
+    ['1.0.0a0.dev1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a0.dev1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc0.dev1', 'minor', undefined, '1.2.0'],
+
+    ['1.0.0a0.dev1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a0.dev1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc0.dev1', 'patch', undefined, '1.1.1'],
+
+    ['1.0.0a0.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1a0.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1rc0.dev1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0a0.dev1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1a0.dev1', 'preminor', undefined, '1.2.0a0'],
+    ['1.1.1rc0.dev1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0a0.dev1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1a0.dev1', 'prepatch', undefined, '1.1.2a0'],
+    ['1.1.1rc0.dev1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0a0.dev1', 'prerelease', undefined, '1.0.0a1'],
+    ['1.0.0rc0.dev1', 'prerelease', undefined, '1.0.0rc1'],
 
     // Development-releases of post-release versions.
     ['1.0.0.post1.dev1', 'major', undefined, '2.0.0'],
     ['1.1.1.post1.dev1', 'major', undefined, '2.0.0'],
+
     ['1.0.0.post1.dev1', 'minor', undefined, '1.1.0'],
     ['1.1.1.post1.dev1', 'minor', undefined, '1.2.0'],
+
     ['1.0.0.post1.dev1', 'patch', undefined, '1.0.1'],
     ['1.1.1.post1.dev1', 'patch', undefined, '1.1.2'],
 
+    ['1.0.0.post1.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1.post1.dev1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0.post1.dev1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1.post1.dev1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0.post1.dev1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1.post1.dev1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0.post1.dev1', 'prerelease', undefined, '1.0.1a0'],
+
     // Development-releases of pre-and-post-release versions.
-    ['1.0.0a1.post1.dev1', 'major', undefined, '1.0.0'],
-    ['1.1.1a1.post1.dev1', 'major', undefined, '2.0.0'],
-    ['1.1.1rc1.post1.dev1', 'major', undefined, '2.0.0'],
-    ['1.0.0a1.post1.dev1', 'minor', undefined, '1.0.0'],
-    ['1.1.1a1.post1.dev1', 'minor', undefined, '1.2.0'],
-    ['1.1.1rc1.post1.dev1', 'minor', undefined, '1.2.0'],
-    ['1.0.0a1.post1.dev1', 'patch', undefined, '1.0.0'],
-    ['1.1.1a1.post1.dev1', 'patch', undefined, '1.1.1'],
-    ['1.1.1rc1.post1.dev1', 'patch', undefined, '1.1.1'],
+    ['1.0.0a0.post1.dev1', 'major', undefined, '1.0.0'],
+    ['1.1.1a0.post1.dev1', 'major', undefined, '2.0.0'],
+    ['1.1.1rc0.post1.dev1', 'major', undefined, '2.0.0'],
+
+    ['1.0.0a0.post1.dev1', 'minor', undefined, '1.0.0'],
+    ['1.1.1a0.post1.dev1', 'minor', undefined, '1.2.0'],
+    ['1.1.1rc0.post1.dev1', 'minor', undefined, '1.2.0'],
+
+    ['1.0.0a0.post1.dev1', 'patch', undefined, '1.0.0'],
+    ['1.1.1a0.post1.dev1', 'patch', undefined, '1.1.1'],
+    ['1.1.1rc0.post1.dev1', 'patch', undefined, '1.1.1'],
+
+    ['1.0.0a0.post1.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1a0.post1.dev1', 'premajor', undefined, '2.0.0a0'],
+    ['1.1.1rc0.post1.dev1', 'premajor', undefined, '2.0.0a0'],
+
+    ['1.0.0a0.post1.dev1', 'preminor', undefined, '1.1.0a0'],
+    ['1.1.1a0.post1.dev1', 'preminor', undefined, '1.2.0a0'],
+    ['1.1.1rc0.post1.dev1', 'preminor', undefined, '1.2.0a0'],
+
+    ['1.0.0a0.post1.dev1', 'prepatch', undefined, '1.0.1a0'],
+    ['1.1.1a0.post1.dev1', 'prepatch', undefined, '1.1.2a0'],
+    ['1.1.1rc0.post1.dev1', 'prepatch', undefined, '1.1.2a0'],
+
+    ['1.0.0a0.post1.dev1', 'prerelease', undefined, '1.0.0a1'],
+    ['1.0.0b0.post1.dev1', 'prerelease', undefined, '1.0.0b1'],
+    ['1.0.0rc0.post1.dev1', 'prerelease', undefined, '1.0.0rc1'],
   ];
 
   testCases.forEach(testCase =>
@@ -156,15 +324,17 @@ describe('inc(version, release)', () => {
     expect(inc(epochTestCase[0], epochTestCase[1], epochTestCase[2])).toBe(epochTestCase[3]));
   });
 
-  const invalidTestCases = [
-    // [ existing version, release type, identifier (`a`, `b`, `rc`, etc.), expected result ]
-
-    // Invalid inputs.
+      // Invalid inputs.
+  const invalidCases = [
     ['not_valid', 'major', undefined, null],
     ['1.0.0', 'invalid_release', undefined, null],
+
+    [`0.0.0`, `premajor`, `alpha`, null],
+    [`0.0.0`, `premajor`, 1, null],
+    [`1.0.0a0`, `premajor`, `alpha`, null]
   ];
 
-  invalidTestCases.forEach(testCase =>
+  invalidCases.forEach(testCase =>
     it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${testCase[3]}`, () =>
     expect(inc(testCase[0], testCase[1], testCase[2])).toBe(testCase[3])));
 });


### PR DESCRIPTION
Add additional support to the `inc` function to increment versions using
the _release types_ `premajor`, `preminor`, `prepatch`, and
`prerelease`.

These additional _release types_ will mirror similar support in the
[`node-semver`](https://github.com/npm/node-semver#functions) package.

Closes #13