### PR TITLE
chore: cleanup code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    node: true
+    node: true,
   },
   extends: ["airbnb-base", "prettier"],
   plugins: ["import", "promise"],
@@ -20,6 +20,6 @@ module.exports = {
     "promise/no-nesting": "warn",
     "promise/no-promise-in-callback": "warn",
     "promise/no-callback-in-promise": "warn",
-    "promise/avoid-new": "warn"
-  }
+    "promise/avoid-new": "warn",
+  },
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {
   satisfies,
   validRange,
   maxSatisfying,
-  minSatisfying
+  minSatisfying,
 } = require("./lib/specifier");
 
 const { major, minor, patch, inc } = require("./lib/semantic");
@@ -40,5 +40,5 @@ module.exports = {
   major,
   minor,
   patch,
-  inc
+  inc,
 };

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -15,7 +15,7 @@ module.exports = {
   "!=": ne,
   ">=": ge,
   ">": gt,
-  "===": arbitrary
+  "===": arbitrary,
 };
 
 function lt(version, other) {
@@ -128,8 +128,8 @@ function calculateKey({ epoch, release, pre, post, dev, local }) {
     // - Numeric segments sort numerically
     // - Shorter versions sort before longer versions when the prefixes
     //   match exactly
-    local = local.map(
-      i => (Number.isNaN(Number(i)) ? [-Infinity, i] : [Number(i), ""])
+    local = local.map((i) =>
+      Number.isNaN(Number(i)) ? [-Infinity, i] : [Number(i), ""]
     );
   }
 

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -5,7 +5,7 @@ module.exports = {
   major,
   minor,
   patch,
-  inc
+  inc,
 };
 
 function major(input) {
@@ -83,7 +83,7 @@ function inc(input, release, preReleaseIdentifier) {
         const [
           majorVersion,
           minorVersion = 0,
-          patchVersion = 0
+          patchVersion = 0,
         ] = version.release;
         version.release.fill(0);
         version.release[0] = majorVersion;
@@ -100,7 +100,7 @@ function inc(input, release, preReleaseIdentifier) {
         const [
           majorVersion,
           minorVersion = 0,
-          patchVersion = 0
+          patchVersion = 0,
         ] = version.release;
         version.release.fill(0);
         version.release[0] = majorVersion;
@@ -126,7 +126,7 @@ function inc(input, release, preReleaseIdentifier) {
       break;
     case "major":
       if (
-        version.release.slice(1).some(value => value !== 0) ||
+        version.release.slice(1).some((value) => value !== 0) ||
         version.pre === null
       ) {
         const [majorVersion] = version.release;
@@ -140,7 +140,7 @@ function inc(input, release, preReleaseIdentifier) {
       break;
     case "minor":
       if (
-        version.release.slice(2).some(value => value !== 0) ||
+        version.release.slice(2).some((value) => value !== 0) ||
         version.pre === null
       ) {
         const [majorVersion, minorVersion = 0] = version.release;
@@ -155,13 +155,13 @@ function inc(input, release, preReleaseIdentifier) {
       break;
     case "patch":
       if (
-        version.release.slice(3).some(value => value !== 0) ||
+        version.release.slice(3).some((value) => value !== 0) ||
         version.pre === null
       ) {
         const [
           majorVersion,
           minorVersion = 0,
-          patchVersion = 0
+          patchVersion = 0,
         ] = version.release;
         version.release.fill(0);
         version.release[0] = majorVersion;

--- a/lib/specifier.js
+++ b/lib/specifier.js
@@ -15,7 +15,7 @@ const RANGE_PATTERN = [
   /*  */ "(?<prefix>\\.\\*)?",
   /*  */ "|",
   /*  */ "(?<legacy>[^,;\\s)]+)",
-  ")"
+  ")",
 ].join("");
 
 module.exports = {
@@ -25,10 +25,10 @@ module.exports = {
   filter,
   validRange,
   maxSatisfying,
-  minSatisfying
+  minSatisfying,
 };
 
-const isEqualityOperator = op => ["==", "!=", "==="].includes(op);
+const isEqualityOperator = (op) => ["==", "!=", "==="].includes(op);
 
 const rangeRegex = new XRegExp("^" + RANGE_PATTERN + "$", "i");
 
@@ -39,8 +39,8 @@ function parse(ranges) {
 
   const specifiers = ranges
     .split(",")
-    .map(range => XRegExp.exec(range.trim(), rangeRegex))
-    .map(groups => {
+    .map((range) => XRegExp.exec(range.trim(), rangeRegex))
+    .map((groups) => {
       if (!groups) {
         return null;
       }
@@ -105,7 +105,7 @@ function pick(versions, specifier, options) {
     return [];
   }
 
-  return versions.filter(version => {
+  return versions.filter((version) => {
     const explained = explainVersion(version);
 
     if (!parsed.length) {
@@ -140,10 +140,7 @@ function contains(specifier, { version, explained }) {
   }
 
   if (spec.operator === "~=") {
-    let compatiblePrefix = spec.release
-      .slice(0, -1)
-      .concat("*")
-      .join(".");
+    let compatiblePrefix = spec.release.slice(0, -1).concat("*").join(".");
     if (spec.epoch) {
       compatiblePrefix = spec.epoch + "!" + compatiblePrefix;
     }

--- a/lib/version.js
+++ b/lib/version.js
@@ -28,7 +28,7 @@ const VERSION_PATTERN = [
   /*    */ "(?<dev_n>[0-9]+)?",
   /* */ ")?",
   ")",
-  "(?:\\+(?<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?" // local version
+  "(?:\\+(?<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?", // local version
 ].join("");
 
 module.exports = {
@@ -37,7 +37,7 @@ module.exports = {
   clean,
   explain,
   parse,
-  stringify
+  stringify,
 };
 
 const validRegex = new XRegExp("^" + VERSION_PATTERN + "$", "i");
@@ -68,7 +68,7 @@ function parse(version, regex) {
       groups.post_n1 || groups.post_n2
     ),
     dev: normalize_letter_version(groups.dev_l, groups.dev_n),
-    local: parse_local_version(groups.local)
+    local: parse_local_version(groups.local),
   };
 
   return parsed;
@@ -148,8 +148,8 @@ function parse_local_version(local) {
   if (local) {
     return local
       .split(/[._-]/)
-      .map(
-        part => (Number.isNaN(Number(part)) ? part.toLowerCase() : Number(part))
+      .map((part) =>
+        Number.isNaN(Number(part)) ? part.toLowerCase() : Number(part)
       );
   }
   return null;
@@ -185,6 +185,6 @@ function explain(version) {
     base_version,
     is_prerelease,
     is_devrelease,
-    is_postrelease
+    is_postrelease,
   };
 }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,11 +1,11 @@
 module.exports = {
   env: {
-    jest: true
+    jest: true,
   },
   rules: {
     "prefer-destructuring": 0,
     "prefer-promise-reject-errors": 0,
     "import/no-extraneous-dependencies": 0,
-    "global-require": 0
-  }
+    "global-require": 0,
+  },
 };

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -56,7 +56,7 @@ const VERSIONS = [
   "1!1.2+1234.abc",
   "1!1.2+123456",
   "1!1.2.r32+123456",
-  "1!1.2.rev33+123456"
+  "1!1.2.rev33+123456",
 ];
 
 const INVALID_VERSIONS = [
@@ -77,13 +77,13 @@ const INVALID_VERSIONS = [
   [],
   null,
   undefined,
-  () => true
+  () => true,
 ];
 
 module.exports = {
   VERSIONS,
   INVALID_VERSIONS,
-  cross
+  cross,
 };
 
 function cross(array, fn) {

--- a/test/operator.test.js
+++ b/test/operator.test.js
@@ -7,44 +7,47 @@ describe("compare(version, other)", () => {
   // should be true/false for the given operator
   [
     ...cross(VERSIONS, (left, i) =>
-      cross(VERSIONS.slice(i + 1), right => [
+      cross(VERSIONS.slice(i + 1), (right) => [
         [left, "<", right, true],
-        [left, ">=", right, false]
+        [left, ">=", right, false],
       ])
     ),
 
     ...cross(VERSIONS, (left, i) =>
-      cross(VERSIONS.slice(i), right => [
+      cross(VERSIONS.slice(i), (right) => [
         [left, "<=", right, true],
-        [left, ">", right, false]
+        [left, ">", right, false],
       ])
     ),
 
-    ...cross(VERSIONS, version => [
+    ...cross(VERSIONS, (version) => [
       [version, "==", version, true],
-      [version, "!=", version, false]
+      [version, "!=", version, false],
     ]),
 
-    ...cross(VERSIONS, left =>
-      cross(VERSIONS.filter(right => right !== left), right => [
-        [left, "!=", right, true],
-        [left, "==", right, false]
-      ])
+    ...cross(VERSIONS, (left) =>
+      cross(
+        VERSIONS.filter((right) => right !== left),
+        (right) => [
+          [left, "!=", right, true],
+          [left, "==", right, false],
+        ]
+      )
     ),
 
     ...cross(VERSIONS, (left, i) =>
-      cross(VERSIONS.slice(0, i + 1), right => [
+      cross(VERSIONS.slice(0, i + 1), (right) => [
         [left, ">=", right, true],
-        [left, "<", right, false]
+        [left, "<", right, false],
       ])
     ),
 
     ...cross(VERSIONS, (left, i) =>
-      cross(VERSIONS.slice(0, i), right => [
+      cross(VERSIONS.slice(0, i), (right) => [
         [left, ">", right, true],
-        [left, "<=", right, false]
+        [left, "<=", right, false],
       ])
-    )
+    ),
   ].forEach(([left, op, right, expected]) => {
     it(`returns ${expected} for '${left}' ${op} '${right}'`, () => {
       expect(operator[op](left, right)).toBe(expected);

--- a/test/semantic.test.js
+++ b/test/semantic.test.js
@@ -1,4 +1,4 @@
-const { major, minor, patch, inc } = require("../");
+const { major, minor, patch, inc } = require("..");
 
 describe("major(version)", () => {
   it("returns correct value", () => {

--- a/test/semantic.test.js
+++ b/test/semantic.test.js
@@ -301,23 +301,19 @@ describe("inc(version, release)", () => {
 
     ["1.0.0a0.post1.dev1", "prerelease", undefined, "1.0.0a1"],
     ["1.0.0b0.post1.dev1", "prerelease", undefined, "1.0.0b1"],
-    ["1.0.0rc0.post1.dev1", "prerelease", undefined, "1.0.0rc1"]
+    ["1.0.0rc0.post1.dev1", "prerelease", undefined, "1.0.0rc1"],
   ];
 
-  testCases.forEach(testCase =>
-    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${
-      testCase[3]
-    }`, () =>
+  testCases.forEach((testCase) =>
+    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${testCase[3]}`, () =>
       expect(inc(testCase[0], testCase[1], testCase[2])).toBe(testCase[3]))
   );
 
-  testCases.forEach(testCase => {
+  testCases.forEach((testCase) => {
     const epochTestCase = testCase;
     epochTestCase[0] = `1!${epochTestCase[0]}`;
     epochTestCase[3] = `1!${epochTestCase[3]}`;
-    it(`handles incrementing ${epochTestCase[0]} using ${epochTestCase[1]} to ${
-      epochTestCase[3]
-    }`, () =>
+    it(`handles incrementing ${epochTestCase[0]} using ${epochTestCase[1]} to ${epochTestCase[3]}`, () =>
       expect(inc(epochTestCase[0], epochTestCase[1], epochTestCase[2])).toBe(
         epochTestCase[3]
       ));
@@ -330,13 +326,11 @@ describe("inc(version, release)", () => {
 
     [`0.0.0`, `premajor`, `foo`, null],
     [`0.0.0`, `premajor`, 1, null],
-    [`1.0.0a0`, `premajor`, `bar`, null]
+    [`1.0.0a0`, `premajor`, `bar`, null],
   ];
 
-  invalidCases.forEach(testCase =>
-    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${
-      testCase[3]
-    }`, () =>
+  invalidCases.forEach((testCase) =>
+    it(`handles incrementing ${testCase[0]} using ${testCase[1]} to ${testCase[3]}`, () =>
       expect(inc(testCase[0], testCase[1], testCase[2])).toBe(testCase[3]))
   );
 });

--- a/test/specifier.test.js
+++ b/test/specifier.test.js
@@ -6,7 +6,7 @@ const {
   satisfies,
   maxSatisfying,
   minSatisfying,
-  filter
+  filter,
 } = require("../lib/specifier");
 
 const SPECIFIERS = [
@@ -19,7 +19,7 @@ const SPECIFIERS = [
   ">=7.9a1",
   "<1.0.dev1",
   ">2.0.post1",
-  "===lolwat"
+  "===lolwat",
 ];
 
 const INVALID_SPECIFIERS = [
@@ -63,17 +63,17 @@ const INVALID_SPECIFIERS = [
 
   // Cannot use a prefix matching after a .devN version
   "==1.0.dev1.*",
-  "!=1.0.dev1.*"
+  "!=1.0.dev1.*",
 ];
 
 describe("parse(range)", () => {
-  SPECIFIERS.forEach(range => {
+  SPECIFIERS.forEach((range) => {
     it("returns parsed for " + JSON.stringify(range), () => {
       expect(parse(range)).not.toBe(null);
       expect(validRange(range)).toBe(true);
     });
   });
-  INVALID_SPECIFIERS.forEach(range => {
+  INVALID_SPECIFIERS.forEach((range) => {
     it("returns null for " + JSON.stringify(range), () => {
       expect(parse(range)).toBe(null);
       expect(validRange(range)).toBe(false);
@@ -194,14 +194,14 @@ describe("parse(range)", () => {
 
     // Various other normalizations
     "v1.0",
-    "  \r \f \v v1.0\t\n"
-  ].forEach(version => {
+    "  \r \f \v v1.0\t\n",
+  ].forEach((version) => {
     it("normalizes " + JSON.stringify(version), () => {
       const ops = ["==", "!="];
       if (!version.includes("+")) {
         ops.push("~=", "<=", ">=", "<", ">");
       }
-      ops.forEach(op => {
+      ops.forEach((op) => {
         expect(parse(op + version)).not.toBe(null);
       });
     });
@@ -214,7 +214,7 @@ describe("parse(range).length", () => {
     ["==2.0", 1],
     [">=2.0", 1],
     [">=2.0,<3", 2],
-    [">=2.0,<3,==2.4", 3]
+    [">=2.0,<3,==2.4", 3],
   ].forEach(([range, length]) => {
     it("returns should be " + length + " for " + JSON.stringify(range), () => {
       expect(parse(range).length).toBe(length);
@@ -317,7 +317,7 @@ describe("satisfies(version, specifier)", () => {
       ["2!1.0", ">2.0"],
 
       // Test some normalization rules
-      ["2.0.5", ">2.0dev"]
+      ["2.0.5", ">2.0dev"],
     ].map(([version, spec]) => [version, spec, true]),
     ...[
       // Test the equality operation
@@ -414,7 +414,7 @@ describe("satisfies(version, specifier)", () => {
       ["1.0", "==2!1.0"],
       ["2!1.0", "==1.*"],
       ["1.0", "==2!1.*"],
-      ["2!1.0", "!=2!1.0"]
+      ["2!1.0", "!=2!1.0"],
     ].map(([version, spec]) => [version, spec, false]),
 
     ...[
@@ -424,8 +424,8 @@ describe("satisfies(version, specifier)", () => {
       ["1.0", "===1.0", true],
       ["nope", "===lolwat", false],
       ["1.0.0", "===1.0", false],
-      ["1.0.dev0", "===1.0.dev0", true]
-    ]
+      ["1.0.dev0", "===1.0.dev0", true],
+    ],
   ].forEach(([version, spec, expected]) => {
     it(`returns ${expected} for ${JSON.stringify(
       version
@@ -443,11 +443,11 @@ describe("satisfies([versions], specifier, {prereleases})", () => {
       ["==2.0.*", "2.0a1.dev1", false],
       ["==2.0a1.*", "2.0a1.dev1", true],
       ["<=2.0", "1.0.dev1", false],
-      ["<=2.0.dev1", "1.0a1", true]
+      ["<=2.0.dev1", "1.0a1", true],
     ],
     ([spec, version, result]) => [
       [spec, version, undefined, result],
-      [spec, version, !result, !result]
+      [spec, version, !result, !result],
     ]
   ).forEach(([spec, version, prereleases, expected]) => {
     it(`returns ${expected} for ${JSON.stringify(
@@ -484,7 +484,7 @@ describe("filter([versions], specifier, {prereleases})", () => {
 
     // Those are not of the original python implimentation
     // but were required for full coverage
-    ["wrong range", false, ["1.0"], []]
+    ["wrong range", false, ["1.0"], []],
   ].forEach(([spec, prereleases, versions, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       versions

--- a/test/version.explain.test.js
+++ b/test/version.explain.test.js
@@ -3,7 +3,7 @@ const { explain } = require("../lib/version");
 const { INVALID_VERSIONS } = require("./fixture");
 
 describe("explain(version)", () => {
-  INVALID_VERSIONS.forEach(version => {
+  INVALID_VERSIONS.forEach((version) => {
     it("returns null for " + JSON.stringify(version), () => {
       expect(explain(version)).toBe(null);
     });
@@ -40,7 +40,7 @@ describe("explain(version).public", () => {
     ["1!1.0a1.post5+deadbeef", "1!1.0a1.post5"],
     ["1!1.0a1.post5.dev6+deadbeef", "1!1.0a1.post5.dev6"],
     ["1!1.0rc4+deadbeef", "1!1.0rc4"],
-    ["1!1.0.post5+deadbeef", "1!1.0.post5"]
+    ["1!1.0.post5+deadbeef", "1!1.0.post5"],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -80,7 +80,7 @@ describe("explain(version).base_version", () => {
     ["1!1.0a1.post5+deadbeef", "1!1.0"],
     ["1!1.0a1.post5.dev6+deadbeef", "1!1.0"],
     ["1!1.0rc4+deadbeef", "1!1.0"],
-    ["1!1.0.post5+deadbeef", "1!1.0"]
+    ["1!1.0.post5+deadbeef", "1!1.0"],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -120,7 +120,7 @@ describe("explain(version).epoch", () => {
     ["1!1.0a1.post5+deadbeef", 1],
     ["1!1.0a1.post5.dev6+deadbeef", 1],
     ["1!1.0rc4+deadbeef", 1],
-    ["1!1.0.post5+deadbeef", 1]
+    ["1!1.0.post5+deadbeef", 1],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -160,7 +160,7 @@ describe("explain(version).release", () => {
     ["1!1.0a1.post5+deadbeef", [1, 0]],
     ["1!1.0a1.post5.dev6+deadbeef", [1, 0]],
     ["1!1.0rc4+deadbeef", [1, 0]],
-    ["1!1.0.post5+deadbeef", [1, 0]]
+    ["1!1.0.post5+deadbeef", [1, 0]],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -200,7 +200,7 @@ describe("explain(version).local", () => {
     ["1!1.0a1.post5+deadbeef", "deadbeef"],
     ["1!1.0a1.post5.dev6+deadbeef", "deadbeef"],
     ["1!1.0rc4+deadbeef", "deadbeef"],
-    ["1!1.0.post5+deadbeef", "deadbeef"]
+    ["1!1.0.post5+deadbeef", "deadbeef"],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -240,7 +240,7 @@ describe("explain(version).pre", () => {
     ["1!1.0a1.post5+deadbeef", ["a", 1]],
     ["1!1.0a1.post5.dev6+deadbeef", ["a", 1]],
     ["1!1.0rc4+deadbeef", ["rc", 4]],
-    ["1!1.0.post5+deadbeef", null]
+    ["1!1.0.post5+deadbeef", null],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -273,7 +273,7 @@ describe("explain(version).is_prerelease", () => {
     ["1.0", false],
     ["1.0+dev", false],
     ["1.0.post1", false],
-    ["1.0.post1+dev", false]
+    ["1.0.post1+dev", false],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -313,7 +313,7 @@ describe("explain(version).dev", () => {
     ["1!1.0a1.post5+deadbeef", null],
     ["1!1.0a1.post5.dev6+deadbeef", 6],
     ["1!1.0rc4+deadbeef", null],
-    ["1!1.0.post5+deadbeef", null]
+    ["1!1.0.post5+deadbeef", null],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -353,7 +353,7 @@ describe("explain(version).is_devrelease", () => {
     ["1!1.0a1.post5+deadbeef", false],
     ["1!1.0a1.post5.dev6+deadbeef", true],
     ["1!1.0rc4+deadbeef", false],
-    ["1!1.0.post5+deadbeef", false]
+    ["1!1.0.post5+deadbeef", false],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -393,7 +393,7 @@ describe("explain(version).post", () => {
     ["1!1.0a1.post5+deadbeef", 5],
     ["1!1.0a1.post5.dev6+deadbeef", 5],
     ["1!1.0rc4+deadbeef", null],
-    ["1!1.0.post5+deadbeef", 5]
+    ["1!1.0.post5+deadbeef", 5],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version
@@ -409,7 +409,7 @@ describe("explain(version).is_postrelease", () => {
     ["1.0", false],
     ["1.0+foo", false],
     ["1.0.post1.dev1", true],
-    ["1.0.post1", true]
+    ["1.0.post1", true],
   ].forEach(([version, expected]) => {
     it(`returns ${JSON.stringify(expected)} for ${JSON.stringify(
       version

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -9,13 +9,13 @@ const { valid, clean } = require("../lib/version");
 const { VERSIONS, INVALID_VERSIONS } = require("./fixture");
 
 describe("valid(version)", () => {
-  VERSIONS.forEach(version => {
+  VERSIONS.forEach((version) => {
     it("returns valid for " + JSON.stringify(version), () => {
       expect(valid(version)).toEqual(version);
     });
   });
 
-  INVALID_VERSIONS.forEach(version => {
+  INVALID_VERSIONS.forEach((version) => {
     it("returns null for " + JSON.stringify(version), () => {
       expect(valid(version)).toBe(null);
     });
@@ -23,7 +23,7 @@ describe("valid(version)", () => {
 });
 
 describe("clean(version)", () => {
-  INVALID_VERSIONS.forEach(version => {
+  INVALID_VERSIONS.forEach((version) => {
     it("returns null for " + JSON.stringify(version), () => {
       expect(clean(version)).toBe(null);
     });
@@ -150,8 +150,8 @@ describe("clean(version)", () => {
     // Various other normalizations
     ["v1.0", "1.0"],
     ["   v1.0\t\n", "1.0"],
-    ["1.0c1", "1.0rc1"]
-  ].forEach(tuple => {
+    ["1.0c1", "1.0rc1"],
+  ].forEach((tuple) => {
     const [version, normalized] = tuple;
     it(`normalizes ${JSON.stringify(version)} to ${JSON.stringify(
       normalized


### PR DESCRIPTION
## Changes:

1. Run command `prettier \"**/*.{js,json,md}\" --write` on current `master`
1. Commit files changed by Prettier run command

## Context:

Clean up code.

## How I've tested this PR:

I've ran `npm run jest` after running the Prettier formatter, and the Jest test pass.

The `npm run lint` command gives a bunch of ESLint warnings, that are all like this:

```
   70:5   warning  Assignment to function parameter 'elem'     no-param-reassign
```

We also get one error from ESLint:

```
pep440\test\semantic.test.js
1:46  error  Useless path segments for "../", should be ".."  import/no-useless-path-segments
```

So probably some code changes are needed to get this to pass all validations.