### PR TITLE
docs(readme): update programming language name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 # pep440
 
-Python PEP440 implementation in JavaScript.
+Python PEP440 implementation in TypeScript.
 
 This logic has been ported from Python for the purposes of use in [Renovate Bot](https://github.com/renovatebot/renovate).


### PR DESCRIPTION
## Changes:

- Replace `JavaScript` with `TypeScript`

## Context:

It looks like we have a mix of JavaScript and TypeScript files in our `lib` directory. Are we planning to migrate to TypeScript?

In any case I think we should probably update the description to match the programming language(s) we're using. 😉 

Found this when working on https://github.com/renovatebot/renovate/pull/16465