### PR TITLE
fix: Revert wrong compatibility specifier logic

### DIFF
--- a/lib/specifier.js
+++ b/lib/specifier.js
@@ -120,12 +120,6 @@ function pick(versions, specifier, options) {
 }
 
 function satisfies(version, specifier, options = {}) {
-  if (specifier.startsWith("~=")) {
-    if (Operator.eq(version, specifier.replace(/^~=\s*/, ""))) {
-      return true;
-    }
-  }
-
   const filtered = pick([version], specifier, options);
 
   return filtered.length === 1;

--- a/test/specifier.test.js
+++ b/test/specifier.test.js
@@ -321,7 +321,6 @@ describe("satisfies(version, specifier)", () => {
       ["3.10", "==3.10.*"],
       ["3.10.0", "==3.10.*"],
       ["0.1.dev123+deadbeef", "==0.1.dev123+deadbeef"],
-      ["0.1.dev123+deadbeef", "~=0.1.dev123+deadbeef"],
 
       // Test some normalization rules
       ["2.0.5", ">2.0dev"],
@@ -417,6 +416,7 @@ describe("satisfies(version, specifier)", () => {
       ["2.0", "~=1.0"],
       ["1.1.0", "~=1.0.0"],
       ["1.1.post1", "~=1.0.0"],
+      ["0.1.dev123+deadbeef", "~=0.1.dev123+deadbeef"],
 
       // Test that epochs are handled sanely
       ["1.0", "~=2!1.0"],


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Revert changes introduced in #269.

## Context

Turns out, specifiers like `~=0.1.dev748+g3349dad` are invalid and we don't have to support them:

```
❯ pip3 install packaging                                                        
Requirement already satisfied: packaging in /opt/homebrew/lib/python3.10/site-packages (23.0)
❯ python3                                                                       
Python 3.10.9 (main, Dec 15 2022, 17:11:09) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from packaging.specifiers import SpecifierSet
>>> SpecifierSet("~=0.1.dev748+g3349dad")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.10/site-packages/packaging/specifiers.py", line 711, in __init__
    parsed.add(Specifier(specifier))
  File "/opt/homebrew/lib/python3.10/site-packages/packaging/specifiers.py", line 245, in __init__
    raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
packaging.specifiers.InvalidSpecifier: Invalid specifier: '~=0.1.dev748+g3349dad'
```

- Ref: #250
