### PR TITLE
fix: wrong argument type in the stringify function

### DIFF
--- a/lib/version.d.ts
+++ b/lib/version.d.ts
@@ -10,6 +10,6 @@ export function parse(
   regex?: RegExp,
 ): Pep440Version | null;
 export function stringify(
-  version: Pep440Version | null | undefined
+  version: Pep440Version | null | undefined,
 ): string | null;
 export function valid(version: string | null | undefined): string | null;

--- a/lib/version.d.ts
+++ b/lib/version.d.ts
@@ -9,5 +9,5 @@ export function parse(
   version: string | null | undefined,
   regex?: RegExp,
 ): Pep440Version | null;
-export function stringify(version: string | null | undefined): string | null;
+export function stringify(version: Pep440Version | null | undefined): string | null;
 export function valid(version: string | null | undefined): string | null;

--- a/lib/version.d.ts
+++ b/lib/version.d.ts
@@ -9,5 +9,7 @@ export function parse(
   version: string | null | undefined,
   regex?: RegExp,
 ): Pep440Version | null;
-export function stringify(version: Pep440Version | null | undefined): string | null;
+export function stringify(
+  version: Pep440Version | null | undefined
+): string | null;
 export function valid(version: string | null | undefined): string | null;


### PR DESCRIPTION
## Changes

Type of `version` argument was changed from `string` to `Pep440Version`

## Context

The function `stringify` formats `Pep440Version` object to a string but has a wrong argument type.
