### PR TITLE
fix: correctly update pypi packages with local version

### DIFF
--- a/lib/specifier.js
+++ b/lib/specifier.js
@@ -170,11 +170,13 @@ function contains(specifier, input) {
     return isEquality ? isMatching : !isMatching;
   }
 
-  if (explained)
-    if (explained.local && spec.version) {
+  if (explained && explained.local && spec.version) {
+    // Ignore candidate local labels only when the specifier itself is public.
+    if (spec.operator !== '===' && !spec.local) {
       version = explained.public;
       spec.version = explainVersion(spec.version).public;
     }
+  }
 
   if (spec.operator === '<' || spec.operator === '>') {
     // simplified version of https://www.python.org/dev/peps/pep-0440/#exclusive-ordered-comparison

--- a/test/specifier.test.js
+++ b/test/specifier.test.js
@@ -260,6 +260,7 @@ describe('satisfies(version, specifier)', () => {
       ['2.0.1', '!=2.0'],
       ['2.0.1', '!=2.0.0'],
       ['2.0', '!=2.0+deadbeef'],
+      ['2.0.1+2', '!=2.0.1+1'],
 
       // Test the in-equality operation with a prefix
       ['2.0', '!=3.*'],
@@ -331,6 +332,7 @@ describe('satisfies(version, specifier)', () => {
       ['2.1', '==2.0'],
       ['2.1', '==2.0.0'],
       ['2.0', '==2.0+deadbeef'],
+      ['2.0.1+2', '==2.0.1+1'],
 
       // Test the equality operation with a prefix
       ['2.0', '==3.*'],
@@ -436,6 +438,9 @@ describe('satisfies(version, specifier)', () => {
       ['nope', '===lolwat', false],
       ['1.0.0', '===1.0', false],
       ['1.0.dev0', '===1.0.dev0', true],
+      ['1.0.0+2', '===1.0.0+2', true],
+      ['1.0.0+2', '===1.0.0', false],
+      ['1.0.0+2', '===1.0.0+1', false],
     ],
   ].forEach(([version, spec, expected]) => {
     it(`returns ${expected} for ${JSON.stringify(


### PR DESCRIPTION
## Changes

Make sure pypi packages with a pinned local version are correctly updated when a newer public version is available.

## Context

Fixes https://github.com/renovatebot/pep440/issues/764.